### PR TITLE
Fix Hugo download command in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,8 +59,8 @@ jobs:
       # 步骤1: 安装Hugo CLI
       - name: Install Hugo CLI
         run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+          wget -O "${{ runner.temp }}/hugo.deb" "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb" \
+            && sudo dpkg -i "${{ runner.temp }}/hugo.deb"
       
       # 步骤2: 检出网站代码仓库
       - name: Checkout website repo
@@ -262,8 +262,8 @@ jobs:
       # 步骤2: 安装 Hugo
       - name: Install Hugo CLI
         run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+          wget -O "${{ runner.temp }}/hugo.deb" "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb" \
+            && sudo dpkg -i "${{ runner.temp }}/hugo.deb"
 
       # 步骤4: 同步新闻文件（增量/全量按 SYNC_MODE）
       - name: Sync markdown files


### PR DESCRIPTION
## Summary
- ensure the Hugo download uses a single URL string so wget succeeds
- apply the same fix to both build and Cloudflare deployment jobs so they share the corrected installer command

## Testing
- not run (CI change only)


------
https://chatgpt.com/codex/tasks/task_e_68ce0dcbae548321a65eb0614ad9a08f