### PR TITLE
Enable collapsible sidebar months

### DIFF
--- a/layouts/_partials/custom/footer.html
+++ b/layouts/_partials/custom/footer.html
@@ -13,9 +13,71 @@ async function load(t,id){
     document.getElementById(id).textContent='—';
   }
 }
-load('total','pv'); 
+load('total','pv');
 load('online','uv');
 setInterval(()=>load('online','uv'),30000);
+</script>
+
+<script type="module">
+const setupSidebarMenuToggle = () => {
+  const sidebar = document.querySelector('aside.sidebar-container');
+  if (!sidebar) return;
+
+  const collapsibleItems = sidebar.querySelectorAll('li[data-collapsible="true"]');
+  collapsibleItems.forEach((item) => {
+    const trigger = item.querySelector(':scope > a[data-sidebar-toggle]');
+    if (!trigger) return;
+
+    const targetId = trigger.getAttribute('aria-controls');
+    if (!targetId) return;
+
+    const panel = document.getElementById(targetId);
+    if (!panel) return;
+
+    const syncState = () => {
+      const expanded = item.classList.contains('open');
+      trigger.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      panel.setAttribute('aria-hidden', expanded ? 'false' : 'true');
+    };
+
+    syncState();
+
+    const observer = new MutationObserver(syncState);
+    observer.observe(item, { attributes: true, attributeFilter: ['class'] });
+
+    const toggle = () => {
+      const expanded = item.classList.contains('open');
+      item.classList.toggle('open', !expanded);
+      syncState();
+    };
+
+    const isModifierClick = (event) => event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0;
+
+    trigger.addEventListener('click', (event) => {
+      if (isModifierClick(event)) return;
+      if (event.target && event.target.closest('.hextra-sidebar-collapsible-button')) {
+        // Default theme script already toggles the state when clicking the chevron button.
+        return;
+      }
+      event.preventDefault();
+      toggle();
+    });
+
+    trigger.addEventListener('keydown', (event) => {
+      const key = event.key;
+      if (key === 'Enter' || key === ' ' || key === 'Spacebar') {
+        event.preventDefault();
+        toggle();
+      }
+    });
+  });
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setupSidebarMenuToggle, { once: true });
+} else {
+  setupSidebarMenuToggle();
+}
 </script>
 
 <div class="footer-wrapper">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,0 +1,200 @@
+{{- $context := .context -}}
+
+{{- $disableSidebar := .disableSidebar | default false -}}
+{{- $displayPlaceholder := .displayPlaceholder | default false -}}
+
+{{- $sidebarClass := cond $disableSidebar (cond $displayPlaceholder "md:hx-hidden xl:hx-block" "md:hx-hidden") "md:hx-sticky" -}}
+
+{{- $navRoot := cond (eq site.Home.Type "docs") site.Home $context.FirstSection -}}
+{{- $pageURL := $context.RelPermalink -}}
+
+{{/* EXPERIMENTAL */}}
+{{- if .context.Params.sidebar.hide -}}
+  {{- $disableSidebar = true -}}
+  {{- $displayPlaceholder = true -}}
+{{- end -}}
+
+
+<div class="mobile-menu-overlay [transition:background-color_1.5s_ease] hx-fixed hx-inset-0 hx-z-10 hx-bg-black/80 dark:hx-bg-black/60 hx-hidden"></div>
+<aside class="sidebar-container hx-flex hx-flex-col print:hx-hidden md:hx-top-16 md:hx-shrink-0 md:hx-w-64 md:hx-self-start max-md:[transform:translate3d(0,-100%,0)] {{ $sidebarClass }}">
+  <!-- Search bar on small screen -->
+  <div class="hx-px-4 hx-pt-4 md:hx-hidden">
+    {{ partial "search.html" }}
+  </div>
+  <div class="hextra-scrollbar hx-overflow-y-auto hx-overflow-x-hidden hx-p-4 hx-grow md:hx-h-[calc(100vh-var(--navbar-height)-var(--menu-height))]">
+    <ul class="hx-flex hx-flex-col hx-gap-1 md:hx-hidden">
+      <!-- Nav -->
+      {{ template "sidebar-main" (dict "context" site.Home "pageURL" $pageURL "page" $context "toc" true) -}}
+      {{ template "sidebar-footer" }}
+    </ul>
+
+    <!-- Sidebar on large screen -->
+    {{- if $disableSidebar -}}
+      {{- if $displayPlaceholder }}<div class="max-xl:hx-hidden hx-h-0 hx-w-64 hx-shrink-0"></div>{{ end -}}
+      {{ .context.Scratch.Set "enableFooterSwitches" true }}
+    {{- else -}}
+      <ul class="hx-flex hx-flex-col hx-gap-1 max-md:hx-hidden">
+        {{ template "sidebar-main" (dict "context" $navRoot "page" $context  "pageURL" $pageURL) }}
+        {{ template "sidebar-footer" }}
+      </ul>
+    {{ end -}}
+  </div>
+  {{/* Hide theme switch when sidebar is disabled */}}
+  {{ $switchesClass := cond $disableSidebar "md:hx-hidden" "" -}}
+  {{ $displayThemeToggle := (site.Params.theme.displayToggle | default true) -}}
+
+  {{ if or hugo.IsMultilingual $displayThemeToggle }}
+    <div class="{{ $switchesClass }} {{ with hugo.IsMultilingual }}hx-justify-end{{ end }} hx-sticky hx-bottom-0 hx-bg-white dark:hx-bg-dark hx-mx-4 hx-py-4 hx-shadow-[0_-12px_16px_#fff] hx-flex hx-items-center hx-gap-2 dark:hx-border-neutral-800 dark:hx-shadow-[0_-12px_16px_#111] contrast-more:hx-border-neutral-400 contrast-more:hx-shadow-none contrast-more:dark:hx-shadow-none hx-border-t" data-toggle-animation="show">
+      {{- with hugo.IsMultilingual -}}
+        {{- partial "language-switch" (dict "context" $context "grow" true) -}}
+        {{- with $displayThemeToggle }}{{ partial "theme-toggle" (dict "hideLabel" true) }}{{ end -}}
+      {{- else -}}
+        {{- with $displayThemeToggle -}}
+          <div class="hx-flex hx-grow hx-flex-col">{{ partial "theme-toggle" }}</div>
+        {{- end -}}
+      {{- end -}}
+    </div>
+  {{- end -}}
+</aside>
+
+{{- define "sidebar-main" -}}
+  {{ template "sidebar-tree" (dict "context" .context "level" 0 "page" .page "pageURL" .pageURL "toc" (.toc | default false)) }}
+{{- end -}}
+
+{{- define "sidebar-tree" -}}
+  {{- if ge .level 4 -}}
+    {{- return -}}
+  {{- end -}}
+
+  {{- $context := .context -}}
+  {{- $page := .page }}
+  {{- $pageURL := .page.RelPermalink -}}
+  {{- $level := .level -}}
+  {{- $toc := .toc | default false -}}
+  {{- $panelID := .panelID -}}
+  {{- $parentOpen := .parentOpen | default true -}}
+
+  {{- with $items := union .context.RegularPages .context.Sections -}}
+    {{- $items = where $items "Params.sidebar.exclude" "!=" true -}}
+    {{- if eq $level 0 -}}
+      {{- range $items.ByWeight }}
+        {{- if .Params.sidebar.separator -}}
+          <li class="[word-break:break-word] hx-mt-5 hx-mb-2 hx-px-2 hx-py-1.5 hx-text-sm hx-font-semibold hx-text-gray-900 first:hx-mt-0 dark:hx-text-gray-100">
+            <span class="hx-cursor-default">{{ partial "utils/title" . }}</span>
+          </li>
+        {{- else -}}
+          {{- $active := eq $pageURL .RelPermalink -}}
+          {{- $shouldOpen := or (.Params.sidebar.open) (.IsAncestor $page) $active | default true }}
+          {{- $hasChildren := or (gt (len .RegularPages) 0) (gt (len .Sections) 0) -}}
+          {{- $cleanPath := strings.TrimSuffix (strings.TrimPrefix .RelPermalink "/") "/" -}}
+          {{- $targetID := cond $hasChildren (printf "sidebar-group-%s" (anchorize $cleanPath)) "" -}}
+          <li class="{{ if $shouldOpen }}open{{ end }}" {{ if $hasChildren }}data-collapsible="true"{{ end }}>
+            {{- $linkTitle := partial "utils/title" . -}}
+            {{- template "sidebar-item-link" dict "context" . "active" $active "title" $linkTitle "link" .RelPermalink "open" $shouldOpen "hasChildren" $hasChildren "targetID" $targetID -}}
+            {{- if and $toc $active -}}
+              {{- template "sidebar-toc" dict "page" . -}}
+            {{- end -}}
+            {{- template "sidebar-tree" dict "context" . "page" $page "pageURL" $pageURL "level" (add $level 1) "toc" $toc "parentOpen" $shouldOpen "panelID" $targetID -}}
+          </li>
+        {{- end -}}
+      {{- end -}}
+    {{- else -}}
+      <div class="ltr:hx-pr-0 hx-overflow-hidden" {{ with $panelID }}id="{{ . }}"{{ end }} data-collapsible-panel aria-hidden="{{ if $parentOpen }}false{{ else }}true{{ end }}">
+        <ul class='hx-relative hx-flex hx-flex-col hx-gap-1 before:hx-absolute before:hx-inset-y-1 before:hx-w-px before:hx-bg-gray-200 before:hx-content-[""] ltr:hx-ml-3 ltr:hx-pl-3 ltr:before:hx-left-0 rtl:hx-mr-3 rtl:hx-pr-3 rtl:before:hx-right-0 dark:before:hx-bg-neutral-800'>
+          {{- range $items.ByWeight }}
+            {{- $active := eq $pageURL .RelPermalink -}}
+            {{- $shouldOpen := or (.Params.sidebar.open) (.IsAncestor $page) $active | default true }}
+            {{- $hasChildren := or (gt (len .RegularPages) 0) (gt (len .Sections) 0) -}}
+            {{- $cleanPath := strings.TrimSuffix (strings.TrimPrefix .RelPermalink "/") "/" -}}
+            {{- $targetID := cond $hasChildren (printf "sidebar-group-%s" (anchorize $cleanPath)) "" -}}
+            {{- $linkTitle := partial "utils/title" . -}}
+            <li class="hx-flex hx-flex-col {{ if $shouldOpen }}open{{ end }}" {{ if $hasChildren }}data-collapsible="true"{{ end }}>
+              {{- template "sidebar-item-link" dict "context" . "active" $active "title" $linkTitle "link" .RelPermalink "open" $shouldOpen "hasChildren" $hasChildren "targetID" $targetID -}}
+              {{- if and $toc $active -}}
+                {{ template "sidebar-toc" dict "page" . }}
+              {{- end }}
+              {{ template "sidebar-tree" dict "context" . "page" $page "pageURL" $pageURL "level" (add $level 1) "toc" $toc "parentOpen" $shouldOpen "panelID" $targetID }}
+            </li>
+          {{- end -}}
+        </ul>
+      </div>
+    {{- end -}}
+  {{- end }}
+{{- end -}}
+
+{{- define "sidebar-toc" -}}
+  {{ $page := .page }}
+  {{ with $page.Fragments.Headings }}
+    <ul class='hx-flex hx-flex-col hx-gap-1 hx-relative before:hx-absolute before:hx-inset-y-1 before:hx-w-px before:hx-bg-gray-200 before:hx-content-[""] dark:before:hx-bg-neutral-800 ltr:hx-pl-3 ltr:before:hx-left-0 rtl:hx-pr-3 rtl:before:hx-right-0 ltr:hx-ml-3 rtl:hx-mr-3'>
+      {{- range . }}
+        {{- with .Headings }}
+          {{- range . -}}
+            <li>
+              <a
+                href="#{{ anchorize .ID }}"
+                class="hx-flex hx-rounded hx-px-2 hx-py-1.5 hx-text-sm hx-transition-colors [word-break:break-word] hx-cursor-pointer [-webkit-tap-highlight-color:transparent] [-webkit-touch-callout:none] contrast-more:hx-border hx-gap-2 before:hx-opacity-25 before:hx-content-['#'] hx-text-gray-500 hover:hx-bg-gray-100 hover:hx-text-gray-900 dark:hx-text-neutral-400 dark:hover:hx-bg-primary-100/5 dark:hover:hx-text-gray-50 contrast-more:hx-text-gray-900 contrast-more:dark:hx-text-gray-50 contrast-more:hx-border-transparent contrast-more:hover:hx-border-gray-900 contrast-more:dark:hover:hx-border-gray-50"
+              >
+                {{- .Title | safeHTML | plainify | htmlUnescape -}}
+              </a>
+            </li>
+          {{ end -}}
+        {{ end -}}
+      {{ end -}}
+    </ul>
+  {{ end }}
+{{- end -}}
+
+{{- define "sidebar-footer" -}}
+  {{- range site.Menus.sidebar -}}
+    {{- $name := or (T .Identifier) .Name -}}
+    {{ if eq .Params.type "separator" }}
+      <li class="[word-break:break-word] hx-mt-5 hx-mb-2 hx-px-2 hx-py-1.5 hx-text-sm hx-font-semibold hx-text-gray-900 first:hx-mt-0 dark:hx-text-gray-100">
+        <span class="hx-cursor-default">{{ $name }}</span>
+      </li>
+    {{ else }}
+      {{- $link := .URL -}}
+      {{- with .PageRef -}}
+        {{- if hasPrefix . "/" -}}
+          {{- $link = relLangURL (strings.TrimPrefix "/" .) -}}
+        {{- end -}}
+      {{- end -}}
+      <li>{{ template "sidebar-item-link" dict "active" false "title" $name "link" $link }}</li>
+    {{ end }}
+  {{- end -}}
+{{- end -}}
+
+{{- define "sidebar-item-link" -}}
+  {{- $external := strings.HasPrefix .link "http" -}}
+  {{- $open := .open | default true -}}
+  {{- $hasChildren := .hasChildren | default false -}}
+  {{- $targetID := .targetID | default "" -}}
+  <a
+    class="hx-flex hx-items-center hx-justify-between hx-gap-2 hx-cursor-pointer hx-rounded hx-px-2 hx-py-1.5 hx-text-sm hx-transition-colors [-webkit-tap-highlight-color:transparent] [-webkit-touch-callout:none] [word-break:break-word]
+    {{- if .active }}
+      sidebar-active-item hx-bg-primary-100 hx-font-semibold hx-text-primary-800 contrast-more:hx-border contrast-more:hx-border-primary-500 dark:hx-bg-primary-400/10 dark:hx-text-primary-600 contrast-more:dark:hx-border-primary-500
+    {{- else }}
+      hx-text-gray-500 hover:hx-bg-gray-100 hover:hx-text-gray-900 contrast-more:hx-border contrast-more:hx-border-transparent contrast-more:hx-text-gray-900 contrast-more:hover:hx-border-gray-900 dark:hx-text-neutral-400 dark:hover:hx-bg-primary-100/5 dark:hover:hx-text-gray-50 contrast-more:dark:hx-text-gray-50 contrast-more:dark:hover:hx-border-gray-50
+    {{- end -}}"
+    href="{{ .link }}"
+    {{- if $hasChildren }}
+      data-sidebar-toggle
+      role="button"
+      aria-expanded="{{ if $open }}true{{ else }}false{{ end }}"
+      {{- with $targetID }} aria-controls="{{ . }}"{{ end -}}
+    {{- end }}
+    {{ if $external }}target="_blank" rel="noreferrer"{{ end }}
+  >
+    {{- .title -}}
+    {{- with .context }}
+      {{- if or .RegularPages .Sections }}
+        <span class="hextra-sidebar-collapsible-button">
+          {{- template "sidebar-collapsible-button" -}}
+        </span>
+      {{- end }}
+    {{ end -}}
+  </a>
+{{- end -}}
+
+{{- define "sidebar-collapsible-button" -}}
+  <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" class="hx-h-[18px] hx-min-w-[18px] hx-rounded-sm hx-p-0.5 hover:hx-bg-gray-800/5 dark:hover:hx-bg-gray-100/5"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" class="hx-origin-center hx-transition-transform rtl:-hx-rotate-180"></path></svg>
+{{- end -}}


### PR DESCRIPTION
## Summary
- override the sidebar partial to add collapse metadata, stable ids, and accessible aria hooks for nested month sections
- add a footer module script that toggles sidebar sections on link clicks while syncing aria state alongside the existing chevron control

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ce244496808321b7e23b1977c8bbe9